### PR TITLE
fix: invert issueLabelErrors.length check

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -112,7 +112,7 @@ async function run(): Promise<void> {
     // Set Output values
     core.setOutput('body-check', bodyCheck)
     core.setOutput('branch-check', branchCheck)
-    core.setOutput('issue-label-check', !!issueLabelErrors.length)
+    core.setOutput('issue-label-check', !issueLabelErrors.length)
     core.setOutput('title-check', titleCheck)
     core.setOutput('watched-files-check', filesFlagged.length === 0)
     const commentsToLeave = []


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🔖 Release
- [ ] 🚩 Other

## Description

If there are issue label errors (truthy `issueLabelErrors.length`) then the check should be _false_... right?

I'm coming back from a long weekend and now getting the logic confused in my head. But I think this is the fix?

## Related Tickets & Documents

Fixes #375.
